### PR TITLE
feat: Use `--disable-dev-shm-usage` when initializing puppeteer

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.13"
+  "version": "1.0.14-alpha.3"
 }

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visual-snapshot/jest-environment",
-  "version": "1.0.13",
+  "version": "1.0.14-alpha.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/jest-environment/src/browser.ts
+++ b/packages/jest-environment/src/browser.ts
@@ -4,7 +4,11 @@ import type { VisualSnapshotConfig } from "./Environment";
 
 const DEFAULT_CONFIG_CI = {
   launch: {
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--disable-dev-shm-usage",
+    ],
   },
   exitOnPageError: true,
 };

--- a/packages/jest-environment/src/teardown.ts
+++ b/packages/jest-environment/src/teardown.ts
@@ -56,10 +56,12 @@ const createSnapshot = async ({
       });
     } catch (err) {
       console.error(new Error(`${testName}: ${err}`));
-      console.warn("...snapshotting full page instead");
-      await page.screenshot({
-        path: imagePath,
-      });
+      if (err.message === "Node has 0 height.") {
+        console.warn("...snapshotting full page instead");
+        return await page.screenshot({
+          path: imagePath,
+        });
+      }
     }
 
     await page.close();

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@visual-snapshot/jest",
-  "version": "1.0.13",
+  "version": "1.0.14-alpha.3",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",
@@ -13,7 +13,7 @@
   "license": "MIT",
   "gitHead": "28ade6650f5cbc8e8dfe5b2b2342dd33ea67167a",
   "dependencies": {
-    "@visual-snapshot/jest-environment": "^1.0.13",
+    "@visual-snapshot/jest-environment": "^1.0.14-alpha.3",
     "typescript": "^3.9.6"
   }
 }


### PR DESCRIPTION
This takes a stab at some jest snapshots that are not saving because of this error: `Protocol error (Page.captureScreenshot): Target closed`

From [puppeteer's troubleshooting docs](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#tips)

> By default, Docker runs a container with a /dev/shm shared memory space 64MB. This is typically too small for Chrome and will cause Chrome to crash when rendering large pages. To fix, run the container with docker run --shm-size=1gb to increase the size of /dev/shm. Since Chrome 65, this is no longer necessary. Instead, launch the browser with the --disable-dev-shm-usage flag: