### PR TITLE
chore: move typescript to dev dependency

### DIFF
--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -20,8 +20,7 @@
     "@sindresorhus/slugify": "^1.0.0",
     "@types/puppeteer": "^3.0.1",
     "jest-environment-jsdom": "^24.9",
-    "puppeteer": "^5.0.0",
-    "typescript": "^3.9.6"
+    "puppeteer": "^5.0.0"
   },
   "gitHead": "28ade6650f5cbc8e8dfe5b2b2342dd33ea67167a",
   "devDependencies": {
@@ -29,7 +28,8 @@
     "@babel/core": "7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
     "@babel/plugin-proposal-optional-chaining": "^7.10.4",
-    "@babel/preset-env": "7.10.4"
+    "@babel/preset-env": "7.10.4",
+    "typescript": "^3.9.6"
   },
   "optionalDependencies": {
     "fsevents": "^2.1.3"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -13,7 +13,9 @@
   "license": "MIT",
   "gitHead": "28ade6650f5cbc8e8dfe5b2b2342dd33ea67167a",
   "dependencies": {
-    "@visual-snapshot/jest-environment": "^1.0.14",
+    "@visual-snapshot/jest-environment": "^1.0.14"
+  },
+  "devDependencies": {
     "typescript": "^3.9.6"
   }
 }


### PR DESCRIPTION
3.9.6 started showing up in sentry