### PR TITLE
chore: upgrade typescript, move to dev dependency

### DIFF
--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -20,8 +20,7 @@
     "@sindresorhus/slugify": "^1.0.0",
     "@types/puppeteer": "^3.0.1",
     "jest-environment-jsdom": "^24.9",
-    "puppeteer": "^5.0.0",
-    "typescript": "^3.9.6"
+    "puppeteer": "^5.0.0"
   },
   "gitHead": "28ade6650f5cbc8e8dfe5b2b2342dd33ea67167a",
   "devDependencies": {
@@ -29,7 +28,8 @@
     "@babel/core": "7.10.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
     "@babel/plugin-proposal-optional-chaining": "^7.10.4",
-    "@babel/preset-env": "7.10.4"
+    "@babel/preset-env": "7.10.4",
+    "typescript": "^4.2"
   },
   "optionalDependencies": {
     "fsevents": "^2.1.3"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -13,7 +13,9 @@
   "license": "MIT",
   "gitHead": "28ade6650f5cbc8e8dfe5b2b2342dd33ea67167a",
   "dependencies": {
-    "@visual-snapshot/jest-environment": "^1.0.14",
-    "typescript": "^3.9.6"
+    "@visual-snapshot/jest-environment": "^1.0.14"
+  },
+  "devDependencies": {
+    "typescript": "^4.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7621,10 +7621,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.9.6:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
+typescript@^4.2:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uglify-js@^3.1.4:
   version "3.6.8"


### PR DESCRIPTION
jest-visual-snapshot listing typescript as a dependency is giving us 2 versions of typescript in sentry